### PR TITLE
fix: use new attribute for repl inspection

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "repl.history": "^0.1.3",
     "require-relative": "^0.8.7",
     "shelljs": "^0.8.5",
-    "shelljs-plugin-clear": "^0.2.0",
-    "shelljs-plugin-inspect": "^0.2.0",
+    "shelljs-plugin-clear": "^0.2.1",
+    "shelljs-plugin-inspect": "^0.2.1",
     "shelljs-plugin-open": "^0.2.0",
     "shelljs-plugin-sleep": "^0.2.1"
   },


### PR DESCRIPTION
This updates the custom inspect implementation to use the preferred
attribute for compatibility with newer node versions.

See nfischer/shelljs-plugin-inspect#9 for more
details.