### PR TITLE
chore: setup codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
+      - uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.swp
 
 node_modules/
+coverage/
+.nyc_output/
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # n\_shell
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fnfischer%2Fn_shell%2Fbadge%3Fref%3Dmain&style=flat-square)](https://actions-badge.atrox.dev/nfischer/n_shell/goto?ref=main)
+[![Codecov](https://img.shields.io/codecov/c/github/nfischer/n_shell.svg?style=flat-square)](https://codecov.io/gh/nfischer/n_shell)
 [![npm version](https://img.shields.io/npm/v/n_shell.svg?style=flat-square)](https://www.npmjs.com/package/n_shell)
 [![npm downloads](https://img.shields.io/npm/dt/n_shell.svg?style=flat-square)](https://www.npmjs.com/package/n_shell)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "posttest": "npm run lint",
-    "test": "mocha test/*.js",
+    "test": "nyc --reporter=text --reporter=lcov mocha test/*.js",
     "lint": "eslint .",
     "changelog": "shelljs-changelog",
     "release:major": "shelljs-release major",
@@ -43,6 +43,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.4",
     "mocha": "^9.2.1",
+    "nyc": "^15.1.0",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.1"
   },


### PR DESCRIPTION
No change to logic. This sets up code coverage for the project, copied
from nfischer/shelljs-exec-proxy.