### PR TITLE
chore: update CI to include latest LTS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ jobs:
           - 10
           - 12
           - 14
+          - 16
+          - 18
+          - 20
+          - 22
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
No change to logic. This updates GitHub actions to test up through the latest node LTS.