### PR TITLE
docs: change GitHub Actions README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # n\_shell
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fnfischer%2Fn_shell%2Fbadge%3Fref%3Dmain&style=flat-square)](https://actions-badge.atrox.dev/nfischer/n_shell/goto?ref=main)
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/nfischer/n_shell/main.yml?style=flat-square&logo=github)](https://github.com/nfischer/n_shell/actions/workflows/main.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/nfischer/n_shell.svg?style=flat-square)](https://codecov.io/gh/nfischer/n_shell)
 [![npm version](https://img.shields.io/npm/v/n_shell.svg?style=flat-square)](https://www.npmjs.com/package/n_shell)
 [![npm downloads](https://img.shields.io/npm/dt/n_shell.svg?style=flat-square)](https://www.npmjs.com/package/n_shell)


### PR DESCRIPTION
This changes the README to use a standard shields.io badge for GitHub Actions. The custom badge
(https://github.com/Atrox/github-actions-badge) was cool, but the atrox.dev link doesn't work reliably. I noticed that shields has support for this now, so there's no reason to use a custom badge.

One notably difference is that this badge says the build is passing even if there's a job still in progress.