### PR TITLE
chore: drop unsupported node versions on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,13 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        exclude:
+          - node-version: 10
+            os: macos-latest
+          - node-version: 12
+            os: macos-latest
+          - node-version: 14
+            os: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
No change to logic. This drops support for older NodeJS versions on macOS because GitHub Actions no longer supports them.