### PR TITLE
chore: update node on GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,20 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 10
-          - 12
-          - 14
+          - 20
+          - 22
+          - 24
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        exclude:
-          - node-version: 10
-            os: macos-latest
-          - node-version: 12
-            os: macos-latest
-          - node-version: 14
-            os: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "shelljs-release": "^0.5.2"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
No change to logic. This adds Node v24 to GitHub Actions CI. This drops official support for Node v18 because it was marked end-of-life in March 2025.