### PR TITLE
chore: update GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,14 +25,14 @@ jobs:
           - node-version: 14
             os: macos-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
No change to logic. This updates GitHub Actions to their latest
versions.

The most important part of this is that it updates codecov to v7, which
contains a major bug fix that was blocking all codecov uploads (and
failing all CI test runs).

No change to the node versions being used on CI.
